### PR TITLE
Fix priority - load bundle after CalendarBundle.

### DIFF
--- a/src/Resources/config/oro/bundles.yml
+++ b/src/Resources/config/oro/bundles.yml
@@ -1,2 +1,3 @@
 bundles:
-    - { name: EHDev\FestivalBasicsBundle\EHDevFestivalBasicsBundle, priority: 10 }
+    # needs to be loaded after Oro CalendarBundle's priority: 101
+    - { name: EHDev\FestivalBasicsBundle\EHDevFestivalBasicsBundle, priority: 102 }


### PR DESCRIPTION
There is a method call in the migration class **AddActivities** (v1_6):
`$activityExtension->addActivityAssociation($schema, 'oro_calendar_event', 'ehdev_fwb_festival_account', true);`

This fails in the installer, because this bundle is loaded after CalendarBundle.

I`ve fixed that by increasing the priority to **102** (see the comment in **bundles.yml**).
